### PR TITLE
Add first year facebook group link to navbar

### DIFF
--- a/components/Navigation.jsx
+++ b/components/Navigation.jsx
@@ -53,7 +53,7 @@ const navLinks = [
   ["Publications", "/publications"],
   ["Charity", "/charity"],
   ["Calendar", "/calendar"],
-  ["First Year FB", "/first-year-fb-group"],
+  ["First Year FB", "/fb"],
 ];
 
 const Navigation = () => {

--- a/components/Navigation.jsx
+++ b/components/Navigation.jsx
@@ -52,7 +52,7 @@ const navLinks = [
   ["Events", "/events"],
   ["Publications", "/publications"],
   ["Charity", "/charity"],
-  // ["Calendar", "/calendar"], // TODO add 2024 calendar
+  ["Calendar", "/calendar"],
   ["First Year FB Group", "/first-year-fb-group"],
 ];
 

--- a/components/Navigation.jsx
+++ b/components/Navigation.jsx
@@ -21,16 +21,12 @@ import Headroom from "headroom.js";
 // reactstrap components
 import {
   Collapse,
-  UncontrolledDropdown,
   Navbar,
   NavItem,
   Nav,
   Container,
   Row,
   Col,
-  DropdownMenu,
-  DropdownItem,
-  DropdownToggle,
   NavbarToggler,
 } from "reactstrap";
 
@@ -47,6 +43,18 @@ import LogoSmall from "public/img/brand/logo_small.png";
 import NextNavbarBrand from "./link/NextNavbarBrand.jsx";
 import NextNavLink from "./link/NextNavLink.jsx";
 import NavIcon from "./navigation/NavIcon.jsx";
+
+// Supports both internal and external links, but internal links/redirects are preferred
+const navLinks = [
+  // [text, link]
+  ["About Us", "/about"],
+  ["Team", "/team"],
+  ["Events", "/events"],
+  ["Publications", "/publications"],
+  ["Charity", "/charity"],
+  // ["Calendar", "/calendar"], // TODO add 2024 calendar
+  ["First Year FB Group", "/first-year-fb-group"],
+];
 
 const Navigation = () => {
   const router = useRouter();
@@ -102,53 +110,15 @@ const Navigation = () => {
                 </Row>
               </div>
               <Nav className="navbar-nav-click align-items-lg-center" navbar>
-                <NavItem>
-                  <Link href="/about" passHref>
-                    <NextNavLink className={getNavLinkClass("/about")}>
-                      <span className="nav-link-inner--text">About Us</span>
-                    </NextNavLink>
-                  </Link>
-                </NavItem>
-
-                <NavItem>
-                  <Link href="/team" passHref>
-                    <NextNavLink className={getNavLinkClass("/team")}>
-                      <span className="nav-link-inner--text">The Team</span>
-                    </NextNavLink>
-                  </Link>
-                </NavItem>
-
-                <NavItem>
-                  <Link href="/events" passHref>
-                    <NextNavLink className={getNavLinkClass("/events")}>
-                      <span className="nav-link-inner--text">Events</span>
-                    </NextNavLink>
-                  </Link>
-                </NavItem>
-
-                <NavItem>
-                  <Link href="/publications" passHref>
-                    <NextNavLink className={getNavLinkClass("/publications")}>
-                      <span className="nav-link-inner--text">Publications</span>
-                    </NextNavLink>
-                  </Link>
-                </NavItem>
-
-                <NavItem>
-                  <Link href="/charity" passHref>
-                    <NextNavLink className={getNavLinkClass("/charity")}>
-                      <span className="nav-link-inner--text">Charity</span>
-                    </NextNavLink>
-                  </Link>
-                </NavItem>
-
-                <NavItem>
-                  <Link href="/calendar" passHref>
-                    <NextNavLink className={getNavLinkClass("/calendar")}>
-                      <span className="nav-link-inner--text">Calendar</span>
-                    </NextNavLink>
-                  </Link>
-                </NavItem>
+                {navLinks.map(([text, link]) => (
+                  <NavItem>
+                    <Link href={link} passHref>
+                      <NextNavLink className={getNavLinkClass(link)}>
+                        <span className="nav-link-inner--text">{text}</span>
+                      </NextNavLink>
+                    </Link>
+                  </NavItem>
+                ))}
               </Nav>
 
               <Nav className="align-items-lg-center ml-lg-auto" navbar>

--- a/components/Navigation.jsx
+++ b/components/Navigation.jsx
@@ -110,8 +110,8 @@ const Navigation = () => {
                 </Row>
               </div>
               <Nav className="navbar-nav-click align-items-lg-center" navbar>
-                {navLinks.map(([text, link]) => (
-                  <NavItem>
+                {navLinks.map(([text, link], index) => (
+                  <NavItem key={`nav-item-${text}-${index}`}>
                     <Link href={link} passHref>
                       <NextNavLink className={getNavLinkClass(link)}>
                         <span className="nav-link-inner--text">{text}</span>

--- a/components/Navigation.jsx
+++ b/components/Navigation.jsx
@@ -53,7 +53,7 @@ const navLinks = [
   ["Publications", "/publications"],
   ["Charity", "/charity"],
   ["Calendar", "/calendar"],
-  ["First Year FB Group", "/first-year-fb-group"],
+  ["First Year FB", "/first-year-fb-group"],
 ];
 
 const Navigation = () => {

--- a/components/merch/MerchCard.jsx
+++ b/components/merch/MerchCard.jsx
@@ -35,7 +35,7 @@ const MerchCard = ({ productData, addToCart }) => {
         key={id}
         onClick={toggle}
       >
-        <img className="card-img-top" src={images[0]} alt={name} />
+        <Image className="card-img-top" src={images[0]} alt={name} />
         <div className="card-body pt-3">
           <h5 className="card-title mb-3">{name}</h5>
           <h5 className="card-subtitle text-muted">
@@ -58,12 +58,17 @@ const MerchCard = ({ productData, addToCart }) => {
                     <div className="images p-3">
                       <div className="text-center p-4">
                         {" "}
-                        <img id="main-image" src={source} width="250" />{" "}
+                        <Image
+                          id="main-image"
+                          src={source}
+                          width="250"
+                          alt={`Main image of ${name}`}
+                        />{" "}
                       </div>
                       {/* <div className="thumbnail text-center">
                           {images.map((src, index) => {
                             return (
-                              <img key={index} onClick={() => changeImage(index)} src={src} width="70"/>
+                              <Image key={index} onClick={() => changeImage(index)} src={src} width="70"/>
                             );
                           })}
                         </div> */}

--- a/next.config.js
+++ b/next.config.js
@@ -14,15 +14,17 @@ const nextConfig = {
   redirects: async () => [
     {
       source: "/calendar",
-      destination: "webcal://calendar.google.com/calendar/ical/pnpcv7pttn3n36herr12kb0lm8%40group.calendar.google.com/public/basic.ics",
+      destination:
+        "webcal://calendar.google.com/calendar/ical/pnpcv7pttn3n36herr12kb0lm8%40group.calendar.google.com/public/basic.ics",
       permanent: false,
     },
     {
-      source: "/first-year-fb-group",
+      // Short link for first year facebook group
+      source: "/fb",
       destination: "https://www.facebook.com/groups/883034036564419/",
       permanent: false,
     },
-  ]
+  ],
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,18 @@ const nextConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, "styles")],
   },
+  redirects: async () => [
+    // {
+    //   source: "/calendar",
+    //   destination: "", // TODO
+    //   permanent: false,
+    // },
+    {
+      source: "/first-year-fb-group",
+      destination: "https://www.facebook.com/groups/883034036564419/",
+      permanent: false,
+    },
+  ]
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -12,11 +12,11 @@ const nextConfig = {
     includePaths: [path.join(__dirname, "styles")],
   },
   redirects: async () => [
-    // {
-    //   source: "/calendar",
-    //   destination: "", // TODO
-    //   permanent: false,
-    // },
+    {
+      source: "/calendar",
+      destination: "webcal://calendar.google.com/calendar/ical/pnpcv7pttn3n36herr12kb0lm8%40group.calendar.google.com/public/basic.ics",
+      permanent: false,
+    },
     {
       source: "/first-year-fb-group",
       destination: "https://www.facebook.com/groups/883034036564419/",


### PR DESCRIPTION
Added first year facebook group link to navbar, refactored navbar to use .map (simplifying how links are added), and added redirect rules to the next config (/first/calendar was sending you to 404 in the dev environment without it).

Update on redirects: turns out we're using cloudflare for the calendar redirect, which is why it wasn't working in the dev environment. We should probably pick either cloudflare or next. I'd say next is easier for us if we (the devs) wanted to add stuff like the first year facebook group to the navbar (while having a professional, easy-to-remember link to share). However, having redirects in cloudflare makes it easier for non-tech people to add redirects (that won't necessarily need to appear visually on the website), like the exec/subcom calendars.

Hovering over the first year group link:
![image](https://github.com/coopsoc/website/assets/40455550/18b4d122-9903-42fa-8552-1b117813976a)

Resolves #55 

