### PR TITLE
Add homepage mobile support

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -10,7 +10,7 @@ import {
   CardText,
   Container,
   Row,
-  CardDeck,
+  Col,
 } from "reactstrap";
 
 // Import Swiper styles
@@ -36,7 +36,7 @@ const Index = () => {
       <section className="section section-lg">
         <Container>
           <Row className="justify-content-center">
-            <CardDeck>
+            <Col md="4">
               <Card className="card-lift--hover shadow border-0 h-100">
                 <CardBody className="py-5 d-flex flex-column">
                   <div className="icon icon-shape icon-shape-style1 rounded-circle mb-3">
@@ -59,6 +59,8 @@ const Index = () => {
                   </div>
                 </CardBody>
               </Card>
+            </Col>
+            <Col md="4">
               <Card className="card-lift--hover shadow border-0 h-100">
                 <CardBody className="py-5 d-flex flex-column">
                   <div className="icon icon-shape icon-shape-style2 rounded-circle mb-3">
@@ -84,6 +86,8 @@ const Index = () => {
                   </div>
                 </CardBody>
               </Card>
+            </Col>
+            <Col md="4">
               <Card className="card-lift--hover shadow border-0 h-100">
                 <CardBody className="py-5 d-flex flex-column">
                   <div className="icon icon-shape icon-shape-style3 rounded-circle mb-3">
@@ -110,7 +114,7 @@ const Index = () => {
                   </div>
                 </CardBody>
               </Card>
-            </CardDeck>
+            </Col>
           </Row>
         </Container>
       </section>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -42,11 +42,11 @@ const Index = () => {
                   <div className="icon icon-shape icon-shape-style1 rounded-circle mb-3">
                     <FontAwesomeIcon icon={niCalendarGrid} />
                   </div>
-                  <div className="justify-content-center text-center mt-3 mb-3">
+                  <div className="justify-content-center text-center mt-2 mt-md-3 mb-md-3">
                     <CardTitle tag="h5" className="text-uppercase">
                       Social Events
                     </CardTitle>
-                    <CardText className="mb-4 mx-0 mx-lg-1">
+                    <CardText className="mb-4 mx-lg-1">
                       At the core of the society, our aims are to socialise and
                       meet new people. We facilitate this through a wide range
                       of social events, including an annual camp and ball.
@@ -66,11 +66,11 @@ const Index = () => {
                   <div className="icon icon-shape icon-shape-style2 rounded-circle mb-3">
                     <FontAwesomeIcon icon={faPencil} />
                   </div>
-                  <div className="justify-content-center text-center mt-3 mb-3">
+                  <div className="justify-content-center text-center mt-2 mt-md-3 mb-md-3">
                     <CardTitle tag="h5" className="text-uppercase">
                       Publications
                     </CardTitle>
-                    <CardText className="mb-4 mx-0 mx-lg-1">
+                    <CardText className="mb-4 mx-lg-1">
                       Our goal with our articles and podcast is to create a
                       platform where scholars past and present can share their
                       experiences, learn something new, and stay connected.
@@ -93,11 +93,11 @@ const Index = () => {
                   <div className="icon icon-shape icon-shape-style3 rounded-circle mb-3">
                     <FontAwesomeIcon icon={faHeart} />
                   </div>
-                  <div className="justify-content-center text-center mt-3 mb-3">
+                  <div className="justify-content-center text-center mt-2 mt-md-3 mb-md-3">
                     <CardTitle tag="h5" className="text-uppercase">
                       Charity Events
                     </CardTitle>
-                    <CardText className="mb-4 mx-0 mx-lg-1">
+                    <CardText className="mb-4 mx-lg-1">
                       The charity portfolio is an integral way for Co-op
                       scholars to give back to the community through events that
                       raise awareness for a diverse range of charities and

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -2,7 +2,16 @@ import React from "react";
 import Head from "next/head";
 
 // Reactstrap components
-import { Button, Card, CardBody, Container, Row, CardDeck } from "reactstrap";
+import {
+  Button,
+  Card,
+  CardBody,
+  CardTitle,
+  CardText,
+  Container,
+  Row,
+  CardDeck,
+} from "reactstrap";
 
 // Import Swiper styles
 import "swiper/css/bundle";
@@ -30,16 +39,18 @@ const Index = () => {
             <CardDeck>
               <Card className="card-lift--hover shadow border-0 h-100">
                 <CardBody className="py-5 d-flex flex-column">
-                  <div className="icon icon-shape icon-shape-style1 rounded-circle mb-4">
+                  <div className="icon icon-shape icon-shape-style1 rounded-circle mb-3">
                     <FontAwesomeIcon icon={niCalendarGrid} />
                   </div>
                   <div className="justify-content-center text-center mt-3 mb-3">
-                    <h6 className="text-uppercase">Social Events</h6>
-                    <p className="description">
+                    <CardTitle tag="h5" className="text-uppercase">
+                      Social Events
+                    </CardTitle>
+                    <CardText className="mb-4 mx-1">
                       At the core of the society, our aims are to socialise and
                       meet new people. We facilitate this through a wide range
                       of social events, including an annual camp and ball.
-                    </p>
+                    </CardText>
                   </div>
                   <div className="justify-content-center text-center mt-auto">
                     <Button className="btn-icon btn-icon-style1" href="/events">
@@ -50,16 +61,18 @@ const Index = () => {
               </Card>
               <Card className="card-lift--hover shadow border-0 h-100">
                 <CardBody className="py-5 d-flex flex-column">
-                  <div className="icon icon-shape icon-shape-style2 rounded-circle mb-4">
+                  <div className="icon icon-shape icon-shape-style2 rounded-circle mb-3">
                     <FontAwesomeIcon icon={faPencil} />
                   </div>
                   <div className="justify-content-center text-center mt-3 mb-3">
-                    <h6 className="text-uppercase">Publications</h6>
-                    <p className="description">
+                    <CardTitle tag="h5" className="text-uppercase">
+                      Publications
+                    </CardTitle>
+                    <CardText className="mb-4 mx-1">
                       Our goal with our articles and podcast is to create a
                       platform where scholars past and present can share their
                       experiences, learn something new, and stay connected.
-                    </p>
+                    </CardText>
                   </div>
                   <div className="justify-content-center text-center mt-auto">
                     <Button
@@ -73,17 +86,19 @@ const Index = () => {
               </Card>
               <Card className="card-lift--hover shadow border-0 h-100">
                 <CardBody className="py-5 d-flex flex-column">
-                  <div className="icon icon-shape icon-shape-style3 rounded-circle mb-4">
+                  <div className="icon icon-shape icon-shape-style3 rounded-circle mb-3">
                     <FontAwesomeIcon icon={faHeart} />
                   </div>
                   <div className="justify-content-center text-center mt-3 mb-3">
-                    <h6 className="text-uppercase">Charity Events</h6>
-                    <p className="description">
+                    <CardTitle tag="h5" className="text-uppercase">
+                      Charity Events
+                    </CardTitle>
+                    <CardText className="mb-4 mx-1">
                       The charity portfolio is an integral way for Co-op
                       scholars to give back to the community through events that
                       raise awareness for a diverse range of charities and
                       social issues.
-                    </p>
+                    </CardText>
                   </div>
                   <div className="justify-content-center text-center mt-auto">
                     <Button

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -33,10 +33,10 @@ const Index = () => {
         <title>UNSW Co-op Society</title>
       </Head>
 
-      <section className="section section-lg">
+      <section className="section my-2 mt-md-4 mb-md-5">
         <Container>
           <Row className="justify-content-center">
-            <Col md="4">
+            <Col md="4" className="mb-4 mb-md-0">
               <Card className="card-lift--hover shadow border-0 h-100">
                 <CardBody className="py-5 d-flex flex-column">
                   <div className="icon icon-shape icon-shape-style1 rounded-circle mb-3">
@@ -46,7 +46,7 @@ const Index = () => {
                     <CardTitle tag="h5" className="text-uppercase">
                       Social Events
                     </CardTitle>
-                    <CardText className="mb-4 mx-1">
+                    <CardText className="mb-4 mx-0 mx-lg-1">
                       At the core of the society, our aims are to socialise and
                       meet new people. We facilitate this through a wide range
                       of social events, including an annual camp and ball.
@@ -60,7 +60,7 @@ const Index = () => {
                 </CardBody>
               </Card>
             </Col>
-            <Col md="4">
+            <Col md="4" className="mb-4 mb-md-0">
               <Card className="card-lift--hover shadow border-0 h-100">
                 <CardBody className="py-5 d-flex flex-column">
                   <div className="icon icon-shape icon-shape-style2 rounded-circle mb-3">
@@ -70,7 +70,7 @@ const Index = () => {
                     <CardTitle tag="h5" className="text-uppercase">
                       Publications
                     </CardTitle>
-                    <CardText className="mb-4 mx-1">
+                    <CardText className="mb-4 mx-0 mx-lg-1">
                       Our goal with our articles and podcast is to create a
                       platform where scholars past and present can share their
                       experiences, learn something new, and stay connected.
@@ -97,7 +97,7 @@ const Index = () => {
                     <CardTitle tag="h5" className="text-uppercase">
                       Charity Events
                     </CardTitle>
-                    <CardText className="mb-4 mx-1">
+                    <CardText className="mb-4 mx-0 mx-lg-1">
                       The charity portfolio is an integral way for Co-op
                       scholars to give back to the community through events that
                       raise awareness for a diverse range of charities and

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -38,8 +38,8 @@ const Index = () => {
           <Row className="justify-content-center">
             <Col md="4" className="mb-4 mb-md-0">
               <Card className="card-lift--hover shadow border-0 h-100">
-                <CardBody className="py-5 d-flex flex-column">
-                  <div className="icon icon-shape icon-shape-style1 rounded-circle mb-3">
+                <CardBody className="py-4 py-md-5 d-flex flex-column">
+                  <div className="icon icon-shape icon-shape-style1 rounded-circle mt-2 mt-md-0 mb-3">
                     <FontAwesomeIcon icon={niCalendarGrid} />
                   </div>
                   <div className="justify-content-center text-center mt-2 mt-md-3 mb-md-3">
@@ -53,7 +53,10 @@ const Index = () => {
                     </CardText>
                   </div>
                   <div className="justify-content-center text-center mt-auto">
-                    <Button className="btn-icon btn-icon-style1" href="/events">
+                    <Button
+                      className="btn-icon btn-icon-style1 mb-3 mb-md-0"
+                      href="/events"
+                    >
                       Learn more
                     </Button>
                   </div>
@@ -62,8 +65,8 @@ const Index = () => {
             </Col>
             <Col md="4" className="mb-4 mb-md-0">
               <Card className="card-lift--hover shadow border-0 h-100">
-                <CardBody className="py-5 d-flex flex-column">
-                  <div className="icon icon-shape icon-shape-style2 rounded-circle mb-3">
+                <CardBody className="py-4 py-md-5 d-flex flex-column">
+                  <div className="icon icon-shape icon-shape-style2 rounded-circle mt-2 mt-md-0 mb-3">
                     <FontAwesomeIcon icon={faPencil} />
                   </div>
                   <div className="justify-content-center text-center mt-2 mt-md-3 mb-md-3">
@@ -78,7 +81,7 @@ const Index = () => {
                   </div>
                   <div className="justify-content-center text-center mt-auto">
                     <Button
-                      className="btn-icon btn-icon-style2"
+                      className="btn-icon btn-icon-style2 mb-3 mb-md-0"
                       href="/publications"
                     >
                       Learn more
@@ -89,8 +92,8 @@ const Index = () => {
             </Col>
             <Col md="4">
               <Card className="card-lift--hover shadow border-0 h-100">
-                <CardBody className="py-5 d-flex flex-column">
-                  <div className="icon icon-shape icon-shape-style3 rounded-circle mb-3">
+                <CardBody className="py-4 py-md-5 d-flex flex-column">
+                  <div className="icon icon-shape icon-shape-style3 rounded-circle mt-2 mt-md-0 mb-3">
                     <FontAwesomeIcon icon={faHeart} />
                   </div>
                   <div className="justify-content-center text-center mt-2 mt-md-3 mb-md-3">
@@ -106,7 +109,7 @@ const Index = () => {
                   </div>
                   <div className="justify-content-center text-center mt-auto">
                     <Button
-                      className="btn-icon btn-icon-style3"
+                      className="btn-icon btn-icon-style3 mb-3 mb-md-0"
                       href="/charity"
                     >
                       Learn more


### PR DESCRIPTION
Resolves #22

Remove (presumably) deprecated CardDeck component and replace with Col to enable a responsive grid layout.

Font size might be slightly too big for smaller breakpoints - I used the `CardText` component as per the docs, which appears to just be a `p` tag - which is 16pt by default. The cards' texts used to have the `description` class, but that made the font too small. As a result, it looks a bit goofy at the medium breakpoint (i.e. viewport width ≥768px, <992px). Looks even weirder having a single column at that breakpoint though, so it's good enough for now.

In future, perhaps someone could set up responsive font sizes - i.e., `CardText` (or perhaps `p` more generally) should shrink as viewport gets smaller.

**Before**
![image](https://github.com/coopsoc/website/assets/40455550/f0a70ebb-2fd7-4d79-9463-e0ba2ff74cfd)
![image](https://github.com/coopsoc/website/assets/40455550/b2126bdc-5e36-441f-bc63-2a1d4abf838a)
![image](https://github.com/coopsoc/website/assets/40455550/51c3a8be-7f2b-4246-922c-4a62025ece2f)
![image](https://github.com/coopsoc/website/assets/40455550/32380660-83d3-455e-97f6-7a4cfe68d6eb)

**After**
![image](https://github.com/coopsoc/website/assets/40455550/dde0a54c-2308-446b-8356-c1d0a3ce941c)
![image](https://github.com/coopsoc/website/assets/40455550/649e78c1-a946-43a3-a10c-cdd29514d9af)
![image](https://github.com/coopsoc/website/assets/40455550/340938c5-15eb-4e96-b27c-9b5939a3cbf6)
![image](https://github.com/coopsoc/website/assets/40455550/e3b66aa6-67b8-494a-8ff0-b155cecc3aa7)
![image](https://github.com/coopsoc/website/assets/40455550/f08705f2-b9ac-4144-b9ee-2476c4b53fba)
(^ viewport width 900px)